### PR TITLE
You can use a macro to simplify this code, and prevent making typos.

### DIFF
--- a/python-dbgeng/constants.cpp
+++ b/python-dbgeng/constants.cpp
@@ -30,10 +30,12 @@ PyModule_AddUnsignedLongLongConstant(PyObject *m,
     return -1;
 }
 
+#define CnstTok(x)      {#x, x}
+
 void AddConstants(PyObject *m)
 {
     struct IntConstantList clist[] = {
-        {"DEBUG_ASMOPT_DEFAULT", DEBUG_ASMOPT_DEFAULT},
+        CnstTok(DEBUG_ASMOPT_DEFAULT),
         {"DEBUG_ASMOPT_VERBOSE", DEBUG_ASMOPT_VERBOSE},
         {"DEBUG_ASMOPT_NO_CODE_BYTES", DEBUG_ASMOPT_NO_CODE_BYTES},
         {"DEBUG_ASMOPT_IGNORE_OUTPUT_WIDTH", DEBUG_ASMOPT_IGNORE_OUTPUT_WIDTH},


### PR DESCRIPTION
Eg:

``` c
    #   define TokVal(x)             #x , x
    #   define BIG_LONG_DEFINED_TERM 99
        printf("%s == %d\n", TokVal(BIG_LONG_DEFINED_TERM));
```
