### PR TITLE
Add missing `not` to `isinstance()` check

### DIFF
--- a/pybag/dbgeng/idebugdataspaces.py
+++ b/pybag/dbgeng/idebugdataspaces.py
@@ -20,7 +20,7 @@ class DebugDataSpaces(object):
         return data[:nread.value]
 
     def WriteVirtual(self, offset, data):
-        if isinstance(data,  bytes):
+        if not isinstance(data,  bytes):
             raise TypeError("data is not bytes")
         nwritten = c_ulong()
         hr = self._data.WriteVirtual(offset, data, len(data), byref(nwritten))


### PR DESCRIPTION
This check is missing the not to have the intended effect. As written, calling with a bytes() instance as the data argument will raise a TypeError, while calling with any other type will erroneously pass this check.