### PR TITLE
Include pybag/dbgeng/win32/ in released builds

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(name='Pybag',
           'Programming Language :: Python',
           'Topic :: Software Development :: Libraries :: Python Modules',
       ],
-      packages=['pybag', 'pybag.dbgeng'],
+      packages=['pybag', 'pybag.dbgeng', 'pybag.dbgeng.win32'],
       package_data={'pybag': ['dbgeng/tlb/*.tlb']},
       include_package_data=True,
       install_requires=[


### PR DESCRIPTION
Added 'pybag.dbgeng.win32' to the list of packages in setup.py, mistakenly omitted in commit 77bede41410d125d432ef9d398287f3b6c823091. With this fix, released builds will now include the .py files in that directory and run without error. 

The PyPi current release, v2.2.7, fails to run out-of-the-box because of this bug.