### PR TITLE
Fix install issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(name='Pybag',
           'Topic :: Software Development :: Libraries :: Python Modules',
       ],
       packages=['pybag', 'pybag.dbgeng'],
-      package_data={'pybag': ['dbgeng/tlb/*.tlb']},
+      package_data={'pybag': ['dbgeng/tlb/*.tlb','dbgeng/win32/*.py']},
       include_package_data=True,
       install_requires=[
           'capstone>=4.0.2',


### PR DESCRIPTION
I know `python.exe ./setup.py install` is not work, because the lib files in pybag,dbgeng.win32 is not installed site-packages folder.
This PR is fix this issue.
I tested on Win10 22H2 and Python 3.10.