### PR TITLE
Improve dbgdir search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,3 @@
 ## Current Changes
-* 2.2.9
-  * Add implementations of GetCurrentThreadSystemId and GetProcessIdsByIndex
+* 2.2.10
+  * Better search for Windbg DLLs using registry and allowing user override

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ k.attach("net:port=50000,key=1.2.3.4")
 
 
 ## Release History
+* 2.2.10
+  * Better search for Windbg DLLs using registry and allowing user override
 * 2.2.9
   * Add implementations of GetCurrentThreadSystemId and GetProcessIdsByIndex
 * 2.2.8

--- a/pybag/__init__.py
+++ b/pybag/__init__.py
@@ -1,25 +1,43 @@
 import ctypes
 import platform
 import os
+import winreg
 
 __all__ = ['UserDbg', 'KernelDbg', 'CrashDbg', 'DbgEng']
 
-# reg query "HKLM\SOFTWARE\Microsoft\Windows Kits\Installed Roots" /v KitsRoot10
 
-if platform.architecture()[0] == '64bit':
-    dbgdirs = [r'C:\Program Files\Windows Kits\10\Debuggers\x64',
-               r'C:\Program Files (x86)\Windows Kits\10\Debuggers\x64']
-else:
-    dbgdirs = [r'C:\Program Files\Windows Kits\10\Debuggers\x86',
-               r'C:\Program Files (x86)\Windows Kits\10\Debuggers\x86']
-dbgdir = None
-for _dir in dbgdirs:
-    if os.path.exists(_dir):
-        dbgdir = _dir
-        break
+def append_arch(dbgroot):
+    if platform.architecture()[0] == '64bit':
+        return os.path.join(dbgroot, r'Debuggers\x64')
+    else:
+        return os.path.join(dbgroot, r'Debuggers\x86')
 
-if not dbgdir:
+
+def find_dbgdir():
+    dbgdir = os.getenv('WINDBG_DIR')
+    if dbgdir is not None and os.path.exists(dbgdir):
+        return dbgdir
+    try:
+        roots_key = winreg.OpenKey(
+            winreg.HKEY_LOCAL_MACHINE,
+            r'SOFTWARE\Microsoft\Windows Kits\Installed Roots')
+        dbgroot = winreg.QueryValueEx(roots_key, 'KitsRoot10')[0]
+        dbgdir = append_arch(dbgroot)
+        if os.path.exists(dbgdir):
+            return dbgdir
+    except FileNotFoundError:
+        pass
+    default_roots = [r'C:\Program Files\Windows Kits\10',
+                     r'C:\Program Files (x86)\Windows Kits\10']
+    for dbgroot in default_roots:
+        dbgdir = append_arch(dbgroot)
+        if os.path.exists(dbgdir):
+            return dbgdir
     raise RuntimeError("Windbg install directory not found!")
+
+
+dbgdir = find_dbgdir()
+
 
 # preload these to get correct DLLs loaded
 try:
@@ -32,10 +50,9 @@ ctypes.windll.LoadLibrary(os.path.join(dbgdir, 'dbgeng.dll'))
 
 del platform
 del os
-del _dir
 del dbgdir
-del dbgdirs
 del ctypes
+del winreg
 
 from .pydbg      import DbgEng
 from .crashdbg   import CrashDbg

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ HERE = pathlib.Path(__file__).parent
 README = (HERE / "README.md").read_text()
 
 setup(name='Pybag',
-      version='2.2.9',
+      version='2.2.10',
       description='Python wrappers for DbgEng from Windbg',
       long_description=README,
       long_description_content_type="text/markdown",


### PR DESCRIPTION
We've improved the search for the Windbg installation directory and related DLLs. Most important for us is the ability to override it. Even if we load from a configured directory first, pybag will load from its found directory upon import, leading to duplicate DLLs being loaded. We figured we could just port the user-override logic upstream and just let pybag do the loading. We accomplish this by preferring the directory given in the `WINDBG_DIR` environment variable, which we would set before invoking Python.

I also went ahead an implemented the lookup via Windows Registry that your comment alluded to. Failing all that, it falls back to the previous logic: search the two default directories.