### PR TITLE
Added note about supported versions of WinDbg.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Pybag provides helper functions on top of Python bindings for Microsoft Debug En
 
 Windows:
 
+Install the Debugging Tools from the Windows SDK here: https://developer.microsoft.com/en-us/windows/downloads/windows-sdk/  Note that neither of the versions of WinDbg from the Microsoft App Store nor the stand-alone installer are currently supported.
+
 ```sh
 python setup.py install
 ```


### PR DESCRIPTION
This PR updates the README to let users know that they must install WinDbg from the Windows SDK; the versions from the Microsoft App Store and stand-alone installer do not work.